### PR TITLE
fix: Resolve duplicate types and empty SFC errors

### DIFF
--- a/frontend/pages/lists/index.vue
+++ b/frontend/pages/lists/index.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container mx-auto py-8 px-4">
+    <h1 class="text-3xl font-bold text-white mb-4">Connection Lists Marketplace</h1>
+    <p class="text-gray-400">This page will display available connection lists or related features.</p>
+    <p class="text-gray-500 mt-2">Feature under development.</p>
+    <!-- Placeholder content for now -->
+    <div class="mt-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <GlassCard v-for="i in 3" :key="i" padding="p-6">
+        <h2 class="text-xl font-semibold text-white mb-2">Connection List Title {{ i }}</h2>
+        <p class="text-gray-400 text-sm mb-4">Brief description of the connection list and its value or category.</p>
+        <AppButton variant="outline" size="sm">View List</AppButton>
+      </GlassCard>
+    </div>
+     <NuxtLink to="/" class="mt-8 inline-block text-quantum-purple hover:underline">Go back to Home</NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Import components if not globally registered and auto-imported
+// import GlassCard from '~/components/ui/GlassCard.vue';
+// import AppButton from '~/components/ui/AppButton.vue';
+
+useHead({
+  title: 'Connection Lists - The Access Marketplace',
+  meta: [
+    { name: 'description', content: 'Discover valuable connection lists on The Access Marketplace.' }
+  ]
+});
+
+definePageMeta({
+  // layout: 'default', // Or a specific layout for lists
+});
+</script>
+
+<style scoped>
+/* Add specific styles for the lists page if needed */
+</style>

--- a/frontend/pages/u/[id].vue
+++ b/frontend/pages/u/[id].vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="container mx-auto py-8 px-4">
+    <h1 class="text-3xl font-bold text-white mb-4">User Profile Page</h1>
+    <p class="text-gray-300">User ID: <span class="text-quantum-purple">{{ $route.params.id }}</span></p>
+    <p class="text-gray-400 mt-2">This page will display the public profile for the user.</p>
+    <!-- Add more profile details here later -->
+    <NuxtLink to="/" class="mt-6 inline-block text-quantum-purple hover:underline">Go back to Home</NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+// import { useRoute } from 'vue-router'; // Nuxt 3 auto-imports useRoute
+const route = useRoute();
+
+// You can fetch user data based on route.params.id here
+// For example:
+// const { data: userProfile, pending, error } = await useFetch(`/api/users/${route.params.id}`);
+
+useHead({
+  title: `Profile for User ${route.params.id} - The Access Marketplace`,
+  meta: [
+    { name: 'description', content: `View the profile of user ${route.params.id}.` }
+  ]
+});
+
+definePageMeta({
+  // layout: 'default', // Or a specific profile layout if created
+});
+</script>
+
+<style scoped>
+/* Add specific styles for the user profile page if needed */
+</style>

--- a/frontend/store/ui.ts
+++ b/frontend/store/ui.ts
@@ -1,18 +1,19 @@
 import { defineStore } from 'pinia';
+import type { AppNotification } from '~/types'; // Import the type
 
-// Define AppNotification first
-export interface AppNotification {
-  id: string;
-  type: 'success' | 'error' | 'info' | 'warning';
-  message: string;
-  duration?: number; // in ms, undefined for persistent
-}
+// The AppNotification interface is now imported from '~/types'
+// export interface AppNotification {
+//   id: string;
+//   type: 'success' | 'error' | 'info' | 'warning';
+//   message: string;
+//   duration?: number; // in ms, undefined for persistent
+// }
 
 interface UIState {
   isPageLoading: boolean;
   isModalOpen: Record<string, boolean>; // e.g., { loginModal: true, bountyFormModal: false }
   theme: 'dark' | 'light'; // If we allow theme switching beyond the default
-  notifications: AppNotification[];
+  notifications: AppNotification[]; // This will now use the imported AppNotification
 }
 
 export const useUIStore = defineStore('ui', {


### PR DESCRIPTION
- Removes duplicate AppNotification interface from store/ui.ts and imports it from ~/types to ensure a single source of truth.
- Adds placeholder content to pages/u/[id].vue and pages/lists/index.vue to resolve empty Single File Component errors encountered during Nuxt dev server startup.